### PR TITLE
Legal move generation

### DIFF
--- a/atomic_move_rules.h
+++ b/atomic_move_rules.h
@@ -33,8 +33,11 @@ class AtomicMoveRules : public IMoveRules {
     Movelist& addLegalBishopMoves(Movelist& mvlist, Position& pos);
     Movelist& addLegalRookMoves(Movelist& mvlist, Position& pos);
     Movelist& addLegalQueenMoves(Movelist& mvlist, Position& pos);
-    Movelist& addLegalPawnCaptures(Movelist& mvlist, Position& pos);
     Movelist& addLegalPawnMoves(Movelist& mvlist, Position& pos);
+    
+    Movelist& addLegalPawnCaptures(Movelist& mvlist, Position& pos);
+    Movelist& addLegalPawnPushes(Movelist& mvlist, Position& pos);
+    Movelist& addLegalPawnDoublePushes(Movelist& mvlist, Position& pos);
     
     Movelist legalOnly(Position& pos);
     bool isCaptureLegal(Square fromSq, Square toSq, const Position& pos);

--- a/atomic_move_rules.h
+++ b/atomic_move_rules.h
@@ -26,6 +26,16 @@ class AtomicMoveRules : public IMoveRules {
     
     private:
     bool isLegalNaive(Move mv, Position& pos);
+    Movelist generateLegalMovesNaive(Position& pos);
+    Movelist& addLegalKingMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalKnightMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalBishopMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalRookMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalQueenMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalPawnMoves(Movelist& mvlist, Position& pos);
+    
+    Movelist legalOnly(Position& pos);
+    bool isCaptureLegal(Square fromSq, Square toSq, const Position& pos);
 };
 
 #endif //#ifndef ATOMIC_MOVE_RULES_INCLUDED

--- a/atomic_move_rules.h
+++ b/atomic_move_rules.h
@@ -29,15 +29,14 @@ class AtomicMoveRules : public IMoveRules {
     Movelist generateLegalMovesNaive(Position& pos);
     // add const-ness to Position& in these methods?
     Movelist& addLegalKingMoves(Movelist& mvlist, Position& pos);
-    Movelist& addLegalKnightMoves(Movelist& mvlist, Position& pos);
-    Movelist& addLegalBishopMoves(Movelist& mvlist, Position& pos);
-    Movelist& addLegalRookMoves(Movelist& mvlist, Position& pos);
-    Movelist& addLegalQueenMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalKnightMoves(Movelist& mvlist, const Position& pos);
+    Movelist& addLegalSliderMoves(Movelist& mvlist, const Position& pos, PieceType pcty);
     Movelist& addLegalPawnMoves(Movelist& mvlist, Position& pos);
     
     Movelist& addLegalPawnCaptures(Movelist& mvlist, Position& pos);
     Movelist& addLegalPawnPushes(Movelist& mvlist, Position& pos);
     Movelist& addLegalPawnDoublePushes(Movelist& mvlist, Position& pos);
+    
     
     Movelist legalOnly(Position& pos);
     bool isCaptureLegal(Square fromSq, Square toSq, const Position& pos);

--- a/atomic_move_rules.h
+++ b/atomic_move_rules.h
@@ -17,29 +17,31 @@ class AtomicMoveRules : public IMoveRules {
     bool isInCheck(Colour co, const Position& pos) override;
     Movelist generateLegalMoves(Position& pos) override;
     
+    bool isLegalNaive(Move mv, Position& pos);
+    
     protected:
     bool isAttacked(Square sq, Colour co, const Position& pos) override;
     bool isCheckAttacked(Square sq, Colour co, const Position& pos) override;
     
-    Bitboard attacksFrom(Square sq, Colour co, PieceType pcty, const Position& pos);
+    protected:
     Bitboard attacksTo(Square sq, Colour co, const Position& pos);
     
     private:
-    bool isLegalNaive(Move mv, Position& pos);
     Movelist generateLegalMovesNaive(Position& pos);
-    // add const-ness to Position& in these methods?
-    Movelist& addLegalKingMoves(Movelist& mvlist, Position& pos);
-    Movelist& addLegalKnightMoves(Movelist& mvlist, const Position& pos);
-    Movelist& addLegalSliderMoves(Movelist& mvlist, const Position& pos, PieceType pcty);
-    Movelist& addLegalPawnMoves(Movelist& mvlist, Position& pos);
     
+    Movelist generateLegalMovesByType(Position& pos);
+    Movelist& addLegalKingMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalKnightMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalSliderMoves(Movelist& mvlist, Position& pos,
+                                  PieceType pcty);
+    Movelist& addLegalPawnMoves(Movelist& mvlist, Position& pos);
     Movelist& addLegalPawnCaptures(Movelist& mvlist, Position& pos);
     Movelist& addLegalPawnPushes(Movelist& mvlist, Position& pos);
     Movelist& addLegalPawnDoublePushes(Movelist& mvlist, Position& pos);
     
-    
-    Movelist legalOnly(Position& pos);
     bool isCaptureLegal(Square fromSq, Square toSq, const Position& pos);
+    bool isLegalNonKingNonCapture(Square fromSq, Square toSq,
+                                  const Position& pos);
     bool isConnectedKings(const Position& pos);
     bool isInterpositionLegal(Square fromSq, Square toSq, const Position& pos);
 };

--- a/atomic_move_rules.h
+++ b/atomic_move_rules.h
@@ -27,15 +27,19 @@ class AtomicMoveRules : public IMoveRules {
     private:
     bool isLegalNaive(Move mv, Position& pos);
     Movelist generateLegalMovesNaive(Position& pos);
+    // add const-ness to Position& in these methods?
     Movelist& addLegalKingMoves(Movelist& mvlist, Position& pos);
     Movelist& addLegalKnightMoves(Movelist& mvlist, Position& pos);
     Movelist& addLegalBishopMoves(Movelist& mvlist, Position& pos);
     Movelist& addLegalRookMoves(Movelist& mvlist, Position& pos);
     Movelist& addLegalQueenMoves(Movelist& mvlist, Position& pos);
+    Movelist& addLegalPawnCaptures(Movelist& mvlist, Position& pos);
     Movelist& addLegalPawnMoves(Movelist& mvlist, Position& pos);
     
     Movelist legalOnly(Position& pos);
     bool isCaptureLegal(Square fromSq, Square toSq, const Position& pos);
+    bool isConnectedKings(const Position& pos);
+    bool isInterpositionLegal(Square fromSq, Square toSq, const Position& pos);
 };
 
 #endif //#ifndef ATOMIC_MOVE_RULES_INCLUDED

--- a/bitboard.h
+++ b/bitboard.h
@@ -102,6 +102,10 @@ inline Bitboard shiftNW(Bitboard bb) {return (bb << 7) & ~BB_H;}
 inline Bitboard shiftSE(Bitboard bb) {return (bb >> 7) & ~BB_A;}
 inline Bitboard shiftSW(Bitboard bb) {return (bb >> 9) & ~BB_H;}
 
+inline Bitboard shiftForward(Bitboard bb, Colour co) {
+    return co == WHITE ? shiftN(bb) : shiftS(bb);
+}
+
 // Test for singly-populated Bitboard
 inline bool isSingle(Bitboard bb) {
     return bb != BB_NONE && (bb & (bb - 1)) == BB_NONE;

--- a/chess_types.h
+++ b/chess_types.h
@@ -118,6 +118,9 @@ inline int getFileIdx(Square sq) {return static_cast<int>(sq) & 7;}
 
 inline Square shiftN(Square sq) {return square(static_cast<int>(sq) + 8);}
 inline Square shiftS(Square sq) {return square(static_cast<int>(sq) - 8);}
+inline Square shiftForward(Square sq, Colour co) {
+    return co == WHITE ? shiftN(sq) : shiftS(sq);
+}
 
 
 // === CastlingRights ===

--- a/move_rules.cpp
+++ b/move_rules.cpp
@@ -104,15 +104,16 @@ Movelist& IMoveRules::addPawnMoves(Movelist& mvlist, Colour co,
             addPawnMoves(mvlist, co, fromSq, toSq);
         }
         // Generate single (and promotions) and double moves.
-        toSq = (co == WHITE) ? shiftN(fromSq) : shiftS(fromSq);
+        toSq = shiftForward(fromSq, co);
         if (!(toSq & bbAll)) {
             // Single moves (and promotions).
             addPawnMoves(mvlist, co, fromSq, toSq);
             // Double moves
             if (fromSq & BB_OUR_2[co]) {
-                toSq = (co == WHITE)
-                    ? shiftN(shiftN(fromSq))
-                    : shiftS(shiftS(fromSq));
+                toSq = shiftForward(shiftForward(fromSq, co), co);
+                //toSq = (co == WHITE)
+                  //  ? shiftN(shiftN(fromSq))
+                    //: shiftS(shiftS(fromSq));
                 if (!(toSq & bbAll)) {
                     mvlist.push_back(buildMove(fromSq, toSq));
                 }

--- a/move_rules.h
+++ b/move_rules.h
@@ -39,10 +39,10 @@ class IMoveRules {
     Movelist& addBishopMoves(Movelist& mvlist, Colour co, const Position& pos);
     Movelist& addRookMoves(Movelist& mvlist, Colour co, const Position& pos);
     Movelist& addQueenMoves(Movelist& mvlist, Colour co, const Position& pos);
-
-    Movelist& addPawnAttacks(Movelist& mvlist, Colour co, const Position& pos);
     Movelist& addPawnMoves(Movelist& mvlist, Colour co, const Position& pos);
     Movelist& addEpMoves(Movelist& mvlist, Colour co, const Position& pos);
+    
+    Movelist& addPawnMoves(Movelist& mvlist, Colour co, Square fromSq, Square toSq);
     
     // Castling validation needs to know which squares are attacked.
     bool isCastlingValid(CastlingRights cr, const Position& pos);

--- a/move_rules.h
+++ b/move_rules.h
@@ -42,13 +42,16 @@ class IMoveRules {
     Movelist& addPawnMoves(Movelist& mvlist, Colour co, const Position& pos);
     Movelist& addEpMoves(Movelist& mvlist, Colour co, const Position& pos);
     
-    Movelist& addPawnMoves(Movelist& mvlist, Colour co, Square fromSq, Square toSq);
+    // Helper method to write pawn moves to movelist.
+    Movelist& addPawnMoves(Movelist& mvlist, Colour co,
+                           Square fromSq, Square toSq);
     
     // Castling validation needs to know which squares are attacked.
     bool isCastlingValid(CastlingRights cr, const Position& pos);
-    Movelist& addCastlingMoves(Movelist& mvlist, Colour co, const Position& pos);
+    Movelist& addCastlingMoves(Movelist& mvlist, Colour co,
+                               const Position& pos);
     
-    // For efficient legal move generation
+    // For efficient legal move generation.
     Bitboard findPinned(Colour co, const Position& pos);
 };
 


### PR DESCRIPTION
Perft tests passing with atomic chess legal move generation, overall time savings of about 16% compared to purely naive legal move generation (24s -> 20s to run perft suites).
Note that perft time savings may not translate to savings in pgn parsing and validation.